### PR TITLE
Remove emote reaction fields from Companion

### DIFF
--- a/SaintCoinach/Definitions/Companion.json
+++ b/SaintCoinach/Definitions/Companion.json
@@ -78,26 +78,6 @@
       "name": "Priority"
     },
     {
-      "index": 18,
-      "name": "Handover"
-    },
-    {
-      "index": 19,
-      "name": "Pet"
-    },
-    {
-      "index": 20,
-      "name": "Beckon"
-    },
-    {
-      "index": 21,
-      "name": "Poke"
-    },
-    {
-      "index": 22,
-      "name": "Slap"
-    },
-    {
       "index": 23,
       "name": "Enemy"
     },


### PR DESCRIPTION
After extensive testing and discussion with @IcarusTwine, we have determined that these fields do not accurately represent minion reactions.