### PR TITLE
Add missing FishingRecordType definitions

### DIFF
--- a/SaintCoinach/Definitions/FishingRecordType.json
+++ b/SaintCoinach/Definitions/FishingRecordType.json
@@ -24,6 +24,14 @@
     {
       "index": 4,
       "name": "RankAAARequirement"
+    },
+    {
+      "index": 5,
+      "name": "RankSRequirement"
+    },
+    {
+      "index": 6,
+      "name": "IsSpearfishing"
     }
   ]
 }


### PR DESCRIPTION
Hopefully I named the flag properly, it uses a 0 or 1 to coerce a boolean. I'm not sure how to in defs, but it may be worth having some kind of "adapter" to flag the 65535 values as null since they indicate the rank isn't available for the record type. A separate PR maybe.