### PR TITLE
Add Chinese UI extract support and a small fix for tripletriad icon

### DIFF
--- a/SaintCoinach.Cmd/Commands/HDUiCommand.cs
+++ b/SaintCoinach.Cmd/Commands/HDUiCommand.cs
@@ -20,7 +20,8 @@ namespace SaintCoinach.Cmd.Commands {
             "/ja",
             "/fr",
             "/de",
-            "/hq"
+            "/hq",
+            "/chs"
         };
 
         private ARealmReversed _Realm;

--- a/SaintCoinach.Cmd/Commands/UiCommand.cs
+++ b/SaintCoinach.Cmd/Commands/UiCommand.cs
@@ -20,7 +20,8 @@ namespace SaintCoinach.Cmd.Commands {
             "/ja",
             "/fr",
             "/de",
-            "/hq"
+            "/hq",
+            "/chs"
         };
 
         private ARealmReversed _Realm;

--- a/SaintCoinach/Xiv/ClassJobActionBase.cs
+++ b/SaintCoinach/Xiv/ClassJobActionBase.cs
@@ -67,7 +67,27 @@ namespace SaintCoinach.Xiv {
         Unknown60,
         Heat,
         Battery,
-        Meditation
+        Meditation,
+        Soul,
+        Shroud,
+        LemureShroud,
+        VoidShroud,
+        Addersgall,
+        Addersting, 
+        Unknown70, // Don't know what's this. maybe a skill dismisser, used by Eukrasian Diagnosis
+        Arcanum, // This is strange, mark this, 1 is ifrit, 2 is titan, 3 is garuda
+        FireAttunement,
+        EarthAttunement,
+        WindAttunement,
+        Firstmind,
+        Paradox,
+        Unknown77,
+        ManaStack,
+        BeastChakra,
+        Unknown80,
+        Coda,
+        Enshrouded,
+        Unknown83, // Don't know what's this for, used by Eukrasian Prognosis
     }
 
     public abstract class ClassJobActionBase : ActionBase {

--- a/SaintCoinach/Xiv/Items/Equipment.cs
+++ b/SaintCoinach/Xiv/Items/Equipment.cs
@@ -85,7 +85,7 @@ namespace SaintCoinach.Xiv.Items {
         ///     Gets the <see cref="Item" /> required to repair the current item.
         /// </summary>
         /// <value>The <see cref="Item" /> required to repair the current item.</value>
-        public Item RepairItem { get { return As<Item>("Item{Repair}"); } }
+        public Item RepairItem { get { return As<XivRow>("Item{Repair}").As<Item>("Name"); } }
 
         /// <summary>
         ///     Gets the type of <see cref="ItemSpecialBonus" /> required to grant additional bonuses of the current item.

--- a/SaintCoinach/Xiv/Items/Equipment.cs
+++ b/SaintCoinach/Xiv/Items/Equipment.cs
@@ -85,7 +85,7 @@ namespace SaintCoinach.Xiv.Items {
         ///     Gets the <see cref="Item" /> required to repair the current item.
         /// </summary>
         /// <value>The <see cref="Item" /> required to repair the current item.</value>
-        public Item RepairItem { get { return As<XivRow>("Item{Repair}").As<Item>("Name"); } }
+        public Item RepairItem { get { return As<XivRow>("Item{Repair}").As<Item>("Item"); } }
 
         /// <summary>
         ///     Gets the type of <see cref="ItemSpecialBonus" /> required to grant additional bonuses of the current item.

--- a/SaintCoinach/Xiv/TripleTriadCard.cs
+++ b/SaintCoinach/Xiv/TripleTriadCard.cs
@@ -9,7 +9,7 @@ using SaintCoinach.Ex.Relational;
 namespace SaintCoinach.Xiv {
     public class TripleTriadCard : XivRow {
         public const int PlateIconOffset = 82100;
-        public const int IconOffset = 82300;
+        public const int IconOffset = 82500;
 
         #region Fields
         private TripleTriadCardResident _Resident;


### PR DESCRIPTION
Only a small fix.
some changes added.
Summary:
1. Tripletriad icon offset calibration.
2. Tried to added missing Aciton Cost Types, names from JobGuide on lodestone.
3. RepairItem now returns an Item rather than XivRow.
4. Small fix to allow SaintCoinach.Cmd to scan Chinese ui assets while using command ui and uiHD.