### PR TITLE
Fix AetherCurrentCompFlgSet off-by-one

### DIFF
--- a/SaintCoinach/Definitions/AetherCurrentCompFlgSet.json
+++ b/SaintCoinach/Definitions/AetherCurrentCompFlgSet.json
@@ -9,7 +9,7 @@
       }
     },
     {
-      "index": 2,
+      "index": 1,
       "type": "repeat",
       "count": 15,
       "definition": {


### PR DESCRIPTION
`AetherCurrentCompFlgSet` accidentally skipped the first AetherCurrent column, leaving it undefined and reading a "16th" AetherCurrent column past the end of the row.

Before
![image](https://user-images.githubusercontent.com/62259674/145181545-a485803c-86ba-4c0a-b060-12a6a0132813.png)

After
![image](https://user-images.githubusercontent.com/62259674/145180295-9e1a1bc3-d0e9-4875-b726-36ff99a6516d.png)
