### PR TITLE
Updated Trust definitions

### DIFF
--- a/SaintCoinach/Definitions/DawnContent.json
+++ b/SaintCoinach/Definitions/DawnContent.json
@@ -11,7 +11,11 @@
     },
     {
       "index": 1,
-      "name": "Exp"
+      "name": "Exp{BelowExMaxLvl}"
+    },
+    {
+      "index": 2,
+      "name": "Exp{AboveExMaxLvl}"
     }
   ]
 }

--- a/SaintCoinach/Definitions/DawnGrowMember.json
+++ b/SaintCoinach/Definitions/DawnGrowMember.json
@@ -11,41 +11,29 @@
     },
     {
       "index": 1,
-      "name": "Image{Name}",
-      "converter": {
-        "type": "icon"
-      }
-    },
-    {
-      "index": 2,
-      "name": "BigImage{Old}",
-      "converter": {
-        "type": "icon"
-      }
-    },
-    {
-      "index": 3,
-      "name": "BigImage{New}",
-      "converter": {
-        "type": "icon"
+      "type": "repeat",
+      "count": 3,
+      "definition": {
+        "name": "SelectImage",
+        "converter": {
+          "type": "icon"
+        }
       }
     },
     {
       "index": 4,
-      "name": "SmallImage{Old}",
-      "converter": {
-        "type": "icon"
+      "type": "repeat",
+      "count": 3,
+      "definition": {
+        "name": "PortraitImage",
+        "converter": {
+          "type": "icon"
+        }
       }
     },
     {
-      "index": 5,
-      "name": "SmallImage{New}",
-      "converter": {
-        "type": "icon"
-      }
-    },
-    {
-      "index": 6,
+
+      "index": 7,
       "name": "Class",
       "converter": {
         "type": "link",

--- a/SaintCoinach/Definitions/DawnQuestAnnounce.json
+++ b/SaintCoinach/Definitions/DawnQuestAnnounce.json
@@ -10,16 +10,12 @@
     },
     {
       "index": 1,
-      "name": "Content",
-      "converter": {
-        "type": "link",
-        "target": "DawnContent"
-      }
+      "name": "QuestStep"
     },
     {
       "index": 2,
       "type": "repeat",
-      "count": 6,
+      "count": 7,
       "definition": {
         "name": "ENPC",
         "converter": {


### PR DESCRIPTION
- Better labeled XP gain columns, per in-game Trust window.
- Adjusted Trust NPC image count for new progression stages.
- Corrected DawnQuestAnnounce's Content column to QuestStep column. This is the quest step the Trust is unlocked during the quest in Quest column.