### PR TITLE
Add ReadKey() to Need Data! error

### DIFF
--- a/SaintCoinach.Cmd/Program.cs
+++ b/SaintCoinach.Cmd/Program.cs
@@ -32,6 +32,8 @@ namespace SaintCoinach.Cmd {
                 dataPath = SearchForDataPaths().FirstOrDefault(p => System.IO.Directory.Exists(p));
             if (string.IsNullOrWhiteSpace(dataPath) || !System.IO.Directory.Exists(dataPath)) {
                 Console.WriteLine($"Need data!  The path '{dataPath}' doesn't exist.");
+                Console.WriteLine("Press any key to exit...");
+                Console.ReadKey();
                 return;
             }
 


### PR DESCRIPTION
In response to Issue #60, the user didn't know CMD couldn't find FFXIV. This will leave the displayed error and path the program is looking for so the user at least knows what the problem is.