### PR TITLE
Fix InstanceContent columns

### DIFF
--- a/SaintCoinach/Definitions/InstanceContent.json
+++ b/SaintCoinach/Definitions/InstanceContent.json
@@ -102,7 +102,11 @@
     },
     {
       "index": 17,
-      "name": "InstanceClearExp"
+      "name": "NewPlayerBonusGil"
+    },
+    {
+      "index": 18,
+      "name": "NewPlayerBonusExp"
     },
     {
       "index": 19,
@@ -110,22 +114,26 @@
     },
     {
       "index": 20,
-      "name": "FinalBossCurrencyC"
-    },
-    {
-      "index": 22,
-      "name": "FinalBossCurrencyA"
-    },
-    {
-      "index": 23,
-      "name": "FinalBossCurrencyB"
-    },
-    {
-      "index": 24,
       "name": "NewPlayerBonusB"
     },
     {
+      "index": 21,
+      "name": "FinalBossExp"
+    },
+    {
+      "index": 23,
+      "name": "FinalBossCurrencyA"
+    },
+    {
+      "index": 24,
+      "name": "FinalBossCurrencyB"
+    },
+    {
       "index": 25,
+      "name": "FinalBossCurrencyC"
+    },
+    {
+      "index": 26,
       "type": "repeat",
       "count": 5,
       "definition": {
@@ -138,7 +146,7 @@
       }
     },
     {
-      "index": 30,
+      "index": 31,
       "type": "repeat",
       "count": 5,
       "definition": {
@@ -151,7 +159,7 @@
       }
     },
     {
-      "index": 35,
+      "index": 36,
       "type": "repeat",
       "count": 5,
       "definition": {
@@ -164,7 +172,7 @@
       }
     },
     {
-      "index": 40,
+      "index": 41,
       "type": "repeat",
       "count": 5,
       "definition": {
@@ -177,20 +185,16 @@
       }
     },
     {
-      "index": 46,
+      "index": 47,
       "name": "InstanceClearGil"
     },
     {
-      "index": 47,
+      "index": 48,
       "name": "InstanceContentRewardItem",
       "converter": {
         "type": "link",
         "target": "InstanceContentRewardItem"
       }
-    },
-    {
-      "index": 49,
-      "name": "FinalBossExp"
     },
     {
       "index": 51,


### PR DESCRIPTION
These changes to `InstanceContent` were derived from comparing Godbert data to the sample data below retrieved from various instance runs. Note that the EXP values do not match up directly due to level scaling (higher level players get an extra multiplier when running lower level instances), but the values do match up when a common multiplier is applied.

**Currency A:** Legacy tomestones
**Currency B:** Current uncapped tomestones
**Currency C:** Weekly capped tomestones

### Pharos Sirius (17)
#### Boss 1
You gain 38,278 (+213%) experience points.
  17,970

You obtain 5 Allagan tomestones of poetics.

#### Boss 2
You gain 66,338 (+210%) experience points.
  31,589
You obtain 10 Allagan tomestones of poetics.

#### Boss 3
You gain 85,310 (+210%) experience points.
  40,623
You obtain 15 Allagan tomestones of poetics.


### Castrum Abania (55)
#### Boss 1
You gain 243,948 (+213%) experience points.
  114,529

#### Boss 2
You gain 426,926 (+213%) experience points.
  200,434

#### Boss 3
You gain 548,906 (+213%) experience points.
  257,702

#### First completion
A bonus of 35,000 experience points and 6,000 gil has been awarded for swift first-time completion of duty objectives.

You obtain 4,140 gil.


### Battle on the Big Bridge (20021)
#### Boss
You gain 3,624 (+210%) experience points.
  1,725
You obtain 10 Allagan tomestones of poetics.

#### First completion
One or more party members completed this duty for the first time. A bonus has been awarded to all members.
You obtain 50 Allagan tomestones of poetics.


### The Stigma Dreamscape (79)
#### Boss 1
You obtain 15 Allagan tomestones of aphorism.

#### Boss 2
You obtain 25 Allagan tomestones of aphorism.

#### Boss 3
You obtain 40 Allagan tomestones of aphorism.
You obtain 50 Allagan tomestones of astronomy.