### PR TITLE
Fill in a bunch of definition files related to portraits and adventurer plates

### DIFF
--- a/SaintCoinach/Definitions/BannerBg.json
+++ b/SaintCoinach/Definitions/BannerBg.json
@@ -1,4 +1,35 @@
 {
   "sheet": "BannerBg",
-  "definitions": []
+  "defaultColumn": "Name",
+  "definitions": [
+    {
+      "name": "Image",
+      "converter": {
+        "type": "icon"
+      }
+    },
+    {
+      "index": 1,
+      "name": "Icon",
+      "converter": {
+        "type": "icon"
+      }
+    },
+    {
+      "index": 2,
+      "name": "UnlockCondition",
+      "converter": {
+        "type": "link",
+        "target": "BannerCondition"
+      }
+    },
+    {
+      "index": 3,
+      "name": "SortKey"
+    },
+    {
+      "index": 4,
+      "name": "Name"
+    }
+  ]
 }

--- a/SaintCoinach/Definitions/BannerCondition.json
+++ b/SaintCoinach/Definitions/BannerCondition.json
@@ -1,4 +1,144 @@
 {
   "sheet": "BannerCondition",
-  "definitions": []
+  "definitions": [
+    {
+      "name": "UnlockType1"
+    },
+    {
+      "index": 1,
+      "name": "UnlockCriteria1",
+      "converter": {
+        "type": "complexlink",
+        "links": [
+          {
+            "when": {
+              "key": "UnlockType1",
+              "value": 1
+            },
+            "sheet": "Quest"
+          },
+          {
+            "when": {
+              "key": "UnlockType1",
+              "value": 5
+            },
+            "sheet": "Emote"
+          }
+        ]
+      }
+    },
+    {
+      "index": 2,
+      "name": "UnlockType2"
+    },
+    {
+      "index": 3,
+      "name": "UnlockCriteria2",
+      "converter": {
+        "type": "complexlink",
+        "links": [
+          {
+            "when": {
+              "key": "UnlockType2",
+              "value": 2
+            },
+            "sheet": "Quest"
+          },
+          {
+            "when": {
+              "key": "UnlockType2",
+              "value": 4
+            },
+            "sheet": "ENpcResident"
+          },
+          {
+            "when": {
+              "key": "UnlockType2",
+              "value": 5
+            },
+            "sheet": "Item"
+          },
+          {
+            "when": {
+              "key": "UnlockType2",
+              "value": 6
+            },
+            "sheet": "Item"
+          },
+          {
+            "when": {
+              "key": "UnlockType2",
+              "value": 7
+            },
+            "sheet": "Item"
+          },
+          {
+            "when": {
+              "key": "UnlockType2",
+              "value": 8
+            },
+            "sheet": "Item"
+          },
+          {
+            "when": {
+              "key": "UnlockType2",
+              "value": 11
+            },
+            "sheet": "Achievement"
+          },
+          {
+            "when": {
+              "key": "UnlockType2",
+              "value": 12
+            },
+            "sheet": "Item"
+          }
+        ]
+      }
+    },
+    {
+      "index": 4,
+      "name": "UnlockCriteria3",
+      "converter": {
+        "type": "complexlink",
+        "links": [
+          {
+            "when": {
+              "key": "UnlockType2",
+              "value": 4
+            },
+            "sheet": "Level"
+          }
+        ]
+      }
+    },
+    {
+      "index": 5,
+      "name": "UnlockCriteria4",
+      "converter": {
+        "type": "complexlink",
+        "links": [
+          {
+            "when": {
+              "key": "UnlockType2",
+              "value": 4
+            },
+            "sheet": "Item"
+          }
+        ]
+      }
+    },
+    {
+      "index": 6,
+      "name": "HasPrerequisite"
+    },
+    {
+      "index": 7,
+      "name": "Prerequisite",
+      "converter": {
+        "type": "link",
+        "target": "Quest"
+      }
+    }
+  ]
 }

--- a/SaintCoinach/Definitions/BannerDecoration.json
+++ b/SaintCoinach/Definitions/BannerDecoration.json
@@ -1,4 +1,35 @@
 {
   "sheet": "BannerDecoration",
-  "definitions": []
+  "defaultColumn": "Name",
+  "definitions": [
+    {
+      "name": "Image",
+      "converter": {
+        "type": "icon"
+      }
+    },
+    {
+      "index": 1,
+      "name": "Icon",
+      "converter": {
+        "type": "icon"
+      }
+    },
+    {
+      "index": 2,
+      "name": "UnlockCondition",
+      "converter": {
+        "type": "link",
+        "target": "BannerCondition"
+      }
+    },
+    {
+      "index": 3,
+      "name": "SortKey"
+    },
+    {
+      "index": 4,
+      "name": "Name"
+    }
+  ]
 }

--- a/SaintCoinach/Definitions/BannerDesignPreset.json
+++ b/SaintCoinach/Definitions/BannerDesignPreset.json
@@ -1,4 +1,37 @@
 {
   "sheet": "BannerDesignPreset",
-  "definitions": []
+  "defaultColumn": "Name",
+  "definitions": [
+    {
+      "name": "Background",
+      "converter": {
+        "type": "link",
+        "target": "BannerBg"
+      }
+    },
+    {
+      "index": 1,
+      "name": "Frame",
+      "converter": {
+        "type": "link",
+        "target": "BannerFrame"
+      }
+    },
+    {
+      "index": 2,
+      "name": "Decoration",
+      "converter": {
+        "type": "link",
+        "target": "BannerDecoration"
+      }
+    },
+    {
+      "index": 3,
+      "name": "SortKey"
+    },
+    {
+      "index": 4,
+      "name": "Name"
+    }
+  ]
 }

--- a/SaintCoinach/Definitions/BannerFacial.json
+++ b/SaintCoinach/Definitions/BannerFacial.json
@@ -1,4 +1,24 @@
 {
   "sheet": "BannerFacial",
-  "definitions": []
+  "definitions": [
+    {
+      "name": "Emote",
+      "converter": {
+        "type": "link",
+        "target": "Emote"
+      }
+    },
+    {
+      "index": 1,
+      "name": "UnlockCondition",
+      "converter": {
+        "type": "link",
+        "target": "BannerCondition"
+      }
+    },
+    {
+      "index": 2,
+      "name": "SortKey"
+    }
+  ]
 }

--- a/SaintCoinach/Definitions/BannerFrame.json
+++ b/SaintCoinach/Definitions/BannerFrame.json
@@ -1,4 +1,35 @@
 {
   "sheet": "BannerFrame",
-  "definitions": []
+  "defaultColumn": "Name",
+  "definitions": [
+    {
+      "name": "Image",
+      "converter": {
+        "type": "icon"
+      }
+    },
+    {
+      "index": 1,
+      "name": "Icon",
+      "converter": {
+        "type": "icon"
+      }
+    },
+    {
+      "index": 2,
+      "name": "UnlockCondition",
+      "converter": {
+        "type": "link",
+        "target": "BannerCondition"
+      }
+    },
+    {
+      "index": 3,
+      "name": "SortKey"
+    },
+    {
+      "index": 4,
+      "name": "Name"
+    }
+  ]
 }

--- a/SaintCoinach/Definitions/BannerTimeline.json
+++ b/SaintCoinach/Definitions/BannerTimeline.json
@@ -1,4 +1,73 @@
 {
   "sheet": "BannerTimeline",
-  "definitions": []
+  "definitions": [
+    {
+      "name": "Type"
+    },
+    {
+      "index": 1,
+      "name": "AdditionalData",
+      "converter": {
+        "type": "complexlink",
+        "links": [
+          {
+            "when": {
+              "key": "Type",
+              "value": 2
+            },
+            "sheet": "Action"
+          },
+          {
+            "when": {
+              "key": "Type",
+              "value": 11
+            },
+            "sheet": "Emote"
+          },
+          {
+            "when": {
+              "key": "Type",
+              "value": 20
+            },
+            "sheet": "ActionTimeline"
+          }
+        ]
+      }
+    },
+    {
+      "index": 2,
+      "name": "AcceptClassJobCategory",
+      "converter": {
+        "type": "link",
+        "target": "ClassJobCategory"
+      }
+    },     
+    {
+      "index": 4,
+      "name": "Category"
+    },
+    {
+      "index": 5,
+      "name": "UnlockCondition",
+      "converter": {
+        "type": "link",
+        "target": "BannerCondition"
+      }
+    },
+    {
+      "index": 6,
+      "name": "SortKey"
+    },
+    {
+      "index": 7,
+      "name": "Icon",
+      "converter": {
+        "type": "icon"
+      }
+    },
+    {
+      "index": 8,
+      "name": "Name"
+    }
+  ]
 }

--- a/SaintCoinach/Definitions/CharaCardBase.json
+++ b/SaintCoinach/Definitions/CharaCardBase.json
@@ -1,4 +1,32 @@
 {
   "sheet": "CharaCardBase",
-  "definitions": []
+  "defaultColumn": "Name",
+  "definitions": [
+    {
+      "name": "Image",
+      "converter": {
+        "type": "icon"
+      }
+    },
+    {
+      "index": 1,
+      "name": "FontColor"
+    },
+    {
+      "index": 5,
+      "name": "UnlockCondition",
+      "converter": {
+        "type": "link",
+        "target": "BannerCondition"
+      }
+    },
+    {
+      "index": 6,
+      "name": "SortKey"
+    },
+    {
+      "index": 7,
+      "name": "Name"
+    }
+  ]
 }

--- a/SaintCoinach/Definitions/CharaCardDecoration.json
+++ b/SaintCoinach/Definitions/CharaCardDecoration.json
@@ -1,4 +1,32 @@
 {
   "sheet": "CharaCardDecoration",
-  "definitions": []
+  "defaultColumn": "Name",
+  "definitions": [
+    {
+      "name": "Category",
+    },
+    {
+      "index": 1,
+      "name": "Image",
+      "converter": {
+        "type": "icon"
+      }
+    },
+    {
+      "index": 3,
+      "name": "UnlockCondition",
+      "converter": {
+        "type": "link",
+        "target": "BannerCondition"
+      }
+    },
+    {
+      "index": 4,
+      "name": "SortKey"
+    },
+    {
+      "index": 5,
+      "name": "Name"
+    }
+  ]
 }

--- a/SaintCoinach/Definitions/CharaCardDesignPreset.json
+++ b/SaintCoinach/Definitions/CharaCardDesignPreset.json
@@ -1,4 +1,77 @@
 {
   "sheet": "CharaCardDesignPreset",
-  "definitions": []
+  "defaultColumn": "Name",
+  "definitions": [
+    {
+      "name": "BasePlate",
+      "converter": {
+        "type": "link",
+        "target": "CharaCardBase"
+      }
+    },
+    {
+      "index": 1,
+      "name": "TopBorder",
+      "converter": {
+        "type": "link",
+        "target": "CharaCardHeader"
+      }
+    },
+    {
+      "index": 2,
+      "name": "BottomBorder",
+      "converter": {
+        "type": "link",
+        "target": "CharaCardHeader"
+      }
+    },
+    {
+      "index": 3,
+      "name": "Backing",
+      "converter": {
+        "type": "link",
+        "target": "CharaCardDecoration"
+      }
+    },
+    {
+      "index": 4,
+      "name": "PatternOverlay",
+      "converter": {
+        "type": "link",
+        "target": "CharaCardDecoration"
+      }
+    },
+    {
+      "index": 5,
+      "name": "PortraitFrame",
+      "converter": {
+        "type": "link",
+        "target": "CharaCardDecoration"
+      }
+    },
+    {
+      "index": 6,
+      "name": "PlateFrame",
+      "converter": {
+        "type": "link",
+        "target": "CharaCardDecoration"
+      }
+    },
+    {
+      "index": 7,
+      "name": "Accent",
+      "converter": {
+        "type": "link",
+        "target": "CharaCardDecoration"
+      }
+    },
+    {
+      "index": 8,
+      "name": "SortKey"
+    },
+    {
+      "index": 9,
+      "name": "Name"
+    }
+  ]
 }

--- a/SaintCoinach/Definitions/CharaCardHeader.json
+++ b/SaintCoinach/Definitions/CharaCardHeader.json
@@ -1,4 +1,31 @@
 {
   "sheet": "CharaCardHeader",
-  "definitions": []
+  "defaultColumn": "Name",
+  "definitions": [
+    {
+      "name": "TopImage",
+      "converter": {
+        "type": "icon"
+      }
+    },
+    {
+      "index": 1,
+      "name": "BottomImage",
+      "converter": {
+        "type": "icon"
+      }
+    },
+    {
+      "index": 2,
+      "name": "FontColor"
+    },
+    {
+      "index": 7,
+      "name": "SortKey"
+    },
+    {
+      "index": 8,
+      "name": "Name"
+    }
+  ]
 }

--- a/SaintCoinach/Definitions/CharaCardPlayStyle.json
+++ b/SaintCoinach/Definitions/CharaCardPlayStyle.json
@@ -1,4 +1,20 @@
 {
   "sheet": "CharaCardPlayStyle",
-  "definitions": []
+  "defaultColumn": "Name",
+  "definitions": [
+    {
+      "name": "Icon",
+      "converter": {
+        "type": "icon"
+      }
+    },
+    {
+      "index": 1,
+      "name": "SortKey"
+    },
+    {
+      "index": 2,
+      "name": "Name"
+    }
+  ]
 }


### PR DESCRIPTION
This fleshes out the JSON definition files for most sheets related to portraits (Banner*) and adventurer plates (CharaCard*)
Most of the information is straight-forward (there's a lot of names/icons/sort orders/etc), with some amount of linking to things like emotes/quests/actions.