### PR TITLE
Update BattleClassIndex on ClassJob definition

### DIFF
--- a/SaintCoinach/Definitions/ClassJob.json
+++ b/SaintCoinach/Definitions/ClassJob.json
@@ -22,7 +22,7 @@
       "name": "ExpArrayIndex"
     },
     {
-      "index": 5,
+      "index": 6,
       "name": "BattleClassIndex"
     },
     {


### PR DESCRIPTION
A new column was added which moved the BattleClassIndex to index 6 instead of 5.