### PR TITLE
Added Attract sheet definition

### DIFF
--- a/SaintCoinach/Definitions/Attract.json
+++ b/SaintCoinach/Definitions/Attract.json
@@ -1,0 +1,24 @@
+﻿{
+  "sheet": "Attract",
+  "definitions": [
+    {
+      "name": "MaxDistance"
+    },
+    {
+      "index": 1,
+      "name": "Speed"
+    },
+    {
+      "index": 2,
+      "name": "MinRemainingDistance"
+    },
+    {
+      "index": 3,
+      "name": "UseDistanceBetweenHitboxes"
+    },
+    {
+      "index": 4,
+      "name": "Direction"
+    }
+  ]
+}


### PR DESCRIPTION
Added definition for an Attract sheet - it is used to describe "reverse knockback" actions (e.g. Rescue role action).

One thing that I didn't figure out is how to describe enum values (e.g. direction column in Attract/Knockback sheets), and in general how to provide comments about columns (e.g. I'd like to describe what 'directionarg' means in Knockback sheet).