### PR TITLE
Removed stray unicode from Attract.json definition

### DIFF
--- a/SaintCoinach/Definitions/Attract.json
+++ b/SaintCoinach/Definitions/Attract.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "sheet": "Attract",
   "definitions": [
     {


### PR DESCRIPTION
I've been using this project's very helpful definitions, but ran into an issue parsing Attract.json with a more strict json parser. Turns out there was a stray \ufeff tagged onto the beginning.