### PR TITLE
Pre-6.3 Sync from Plugin Devs

### DIFF
--- a/SaintCoinach/Definitions/Aetheryte.json
+++ b/SaintCoinach/Definitions/Aetheryte.json
@@ -100,6 +100,10 @@
     {
       "index": 22,
       "name": "Aetherstream{Y}"
+    },
+    {
+      "index": 23,
+      "name": "Order"
     }
   ]
 }

--- a/SaintCoinach/Definitions/ExtraCommand.json
+++ b/SaintCoinach/Definitions/ExtraCommand.json
@@ -1,0 +1,24 @@
+{
+  "sheet": "ExtraCommand",
+  "defaultColumn": "Name",
+  "definitions": [
+    {
+      "name": "Name"
+    },
+    {
+      "index": 1,
+      "name": "Description"
+    },
+    {
+      "index": 2,
+      "name": "Icon",
+      "converter": {
+        "type": "icon"
+      }
+    },
+    {
+      "index": 3,
+      "name": "Order"
+    }
+  ]
+}

--- a/SaintCoinach/Definitions/FashionCheckThemeCategory.json
+++ b/SaintCoinach/Definitions/FashionCheckThemeCategory.json
@@ -1,0 +1,9 @@
+{
+  "sheet": "FashionCheckThemeCategory",
+  "defaultColumn": "Name",
+  "definitions": [
+    {
+      "name": "Name"
+    }
+  ]
+}

--- a/SaintCoinach/Definitions/FashionCheckWeeklyTheme.json
+++ b/SaintCoinach/Definitions/FashionCheckWeeklyTheme.json
@@ -1,0 +1,9 @@
+{
+  "sheet": "FashionCheckWeeklyTheme",
+  "defaultColumn": "Name",
+  "definitions": [
+    {
+      "name": "Name"
+    }
+  ]
+}

--- a/SaintCoinach/Definitions/McGuffin.json
+++ b/SaintCoinach/Definitions/McGuffin.json
@@ -1,0 +1,12 @@
+{
+  "sheet": "McGuffin",
+  "definitions": [
+    {
+      "name": "UIData",
+      "converter": {
+        "type": "link",
+        "target": "McGuffinUIData"
+      }
+    }
+  ]
+}

--- a/SaintCoinach/Definitions/McGuffinUIData.json
+++ b/SaintCoinach/Definitions/McGuffinUIData.json
@@ -1,0 +1,19 @@
+{
+  "sheet": "McGuffinUIData",
+  "definitions": [
+    {
+      "name": "Order"
+    },
+    {
+      "index": 1,
+      "name": "Icon",
+      "converter": {
+        "type": "icon"
+      }
+    },
+    {
+      "index": 2,
+      "name": "Name"
+    }
+  ]
+}

--- a/SaintCoinach/Definitions/Quest.json
+++ b/SaintCoinach/Definitions/Quest.json
@@ -451,24 +451,12 @@
     {
       "index": 1221,
       "type": "repeat",
-      "count": 24,
-      "definition": {
-        "name": "ToDoMainLocation",
-        "converter": {
-          "type": "link",
-          "target": "Level"
-        }
-      }
-    },
-    {
-      "index": 1245,
-      "type": "repeat",
-      "count": 7,
+      "count": 8,
       "definition": {
         "type": "repeat",
         "count": 24,
         "definition": {
-          "name": "ToDoChildLocation",
+          "name": "ToDoLocation",
           "converter": {
             "type": "link",
             "target": "Level"

--- a/SaintCoinach/Definitions/Treasure.json
+++ b/SaintCoinach/Definitions/Treasure.json
@@ -4,10 +4,10 @@
   "definitions": [
     {
       "index": 8,
-      "name": "Item",
+      "name": "SGB",
       "converter": {
         "type": "link",
-        "target": "Item"
+        "target": "ExportedSG"
       }
     }
   ]


### PR DESCRIPTION
This PR aims to bring in a handful of small updates found by various plugin developers, all compiled into one pull request. In no particular order:

- Add definitions for `McGuffin`, `McGuffinUIData`, and `ExtraCommand` 
- Add definitions for `FashionCheckThemeCategory` and `FashionCheckWeeklyTheme` (@Kalilistic) 
- Add `Order` column to `Aetheryte` sheet, used to display UI order and probably grouping
- [BREAKING] Merge `ToDoMainLocation` and `ToDoChildLocation` to `ToDoLocation` in `Quest` to better reflect game behavior (@midorikami)
- [BREAKING] Replace `Item` with `SGB` in `Treasure` (@pohky) 