### PR TITLE
[CI] Fix releases not including build zips

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          files: release-out\**
+          files: release-out/**
           name: Release for ${{ steps.define-version.outputs.commit }}
           body_path:  .github\RELEASE.md
           prerelease: false


### PR DESCRIPTION
The release builds are no longer including the pre-built binaries due to a breaking change in the github action being used. 
- [Example from the latest build on Dec 31st](https://github.com/xivapi/SaintCoinach/actions/runs/3811474249/jobs/6484175549#step:8:13) - [Output](https://github.com/xivapi/SaintCoinach/releases/tag/ebeb203)
- [Example from the latest "successful" build on Nov 16th](https://github.com/xivapi/SaintCoinach/actions/runs/3477968559/jobs/5814764126#step:8:14) - [Output](https://github.com/xivapi/SaintCoinach/releases/tag/7760530)

Sometime mid November, [softprops/action-gh-release@v1](https://github.com/softprops/action-gh-release) updated the node-glob dependency to 8.0, which [changed](https://github.com/isaacs/node-glob/blob/main/changelog.md#80) the behavior of `\` to only be an escape character rather than a path separator. 

This PR resolves this by changing the files path used by this action to use a forward slash instead.
ref: softprops/action-gh-release#280