### PR TITLE
Update QuestLinkMarker

### DIFF
--- a/SaintCoinach/Definitions/QuestLinkMarker.json
+++ b/SaintCoinach/Definitions/QuestLinkMarker.json
@@ -1,4 +1,29 @@
 {
   "sheet": "QuestLinkMarker",
-  "definitions": []
+  "definitions": [
+    {
+      "index": 0,
+      "name": "SourceMap",
+      "converter": {
+        "type": "link",
+        "target": "Map"
+      }
+    },
+    {
+      "index": 1,
+      "name": "Level",
+      "converter": {
+        "type": "link",
+        "target": "Level"
+      }
+    },
+    {
+      "index": 2,
+      "name": "TargetMap",
+      "converter": {
+        "type": "link",
+        "target": "Map"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
This sheet contains information pertaining to the "quest is in a sub area" marker system added recently.

The first column is the source map id, that is the mapid the marker will appear in.
The second column is the Level data that contains the coordinates of the marker.
The third column is the destination map id, when the marker is clicked on from the main map, it will cause the map to show the destination id's map.

This is my first time trying to contribute a definition, I may have messed up the formatting >_<