### PR TITLE
Add HideOrder column to CabinetCategory

### DIFF
--- a/SaintCoinach/Definitions/CabinetCategory.json
+++ b/SaintCoinach/Definitions/CabinetCategory.json
@@ -7,13 +7,17 @@
     },
     {
       "index": 1,
+      "name": "HideOrder"
+    },
+    {
+      "index": 2,
       "name": "Icon",
       "converter": {
         "type": "icon"
       }
     },
     {
-      "index": 2,
+      "index": 3,
       "name": "Category",
       "converter": {
         "type": "link",


### PR DESCRIPTION
Adds the new `HideOrder` column which indicates that an Armoire category is hidden by default until you obtain something in that category, similar to OrchestrionCategory.