### PR TITLE
fix: EF6 config for .net 7

### DIFF
--- a/SaintCoinach.Cmd/App.config
+++ b/SaintCoinach.Cmd/App.config
@@ -5,6 +5,7 @@
       <section name="SaintCoinach.Cmd.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
     </sectionGroup>
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
+    <section name="system.data" type="System.Data.Common.DbProviderFactoriesConfigurationHandler, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
   </configSections>
   <startup>

--- a/SaintCoinach/Xiv/TripleTriadCard.cs
+++ b/SaintCoinach/Xiv/TripleTriadCard.cs
@@ -8,8 +8,8 @@ using SaintCoinach.Ex.Relational;
 
 namespace SaintCoinach.Xiv {
     public class TripleTriadCard : XivRow {
-        public const int PlateIconOffset = 82100;
-        public const int IconOffset = 82500;
+        public const int PlateIconOffset = 87000;
+        public const int IconOffset = 88000;
 
         #region Fields
         private TripleTriadCardResident _Resident;

--- a/SaintCoinach/app.config
+++ b/SaintCoinach/app.config
@@ -3,9 +3,10 @@
   <configSections>
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+    <section name="system.data" type="System.Data.Common.DbProviderFactoriesConfigurationHandler, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   </configSections>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
+    
   </startup>
   <system.data>
     <DbProviderFactories>


### PR DESCRIPTION
this fix 
"Unhandled exception. System.Configuration.ConfigurationErrorsException: Configuration system failed to initialize
 ---> System.Configuration.ConfigurationErrorsException: Unrecognized configuration section system.data."
when launching SaintCoinach.Cmd
but EF6 data provider is not actually registered, makes libra data not usable, further config update is still required, may be update later

and tripletriad icon offset fix