### PR TITLE
Add PreviousQuest[3] to Quest definition

### DIFF
--- a/SaintCoinach/Definitions/Quest.json
+++ b/SaintCoinach/Definitions/Quest.json
@@ -54,7 +54,7 @@
       "index": 9,
       "name": "PreviousQuest",
       "type": "repeat",
-      "count": 3,
+      "count": 4,
       "definition": {
         "name": "PreviousQuest",
         "converter": {


### PR DESCRIPTION
Quests can have up to 4 pre-requisites (e.g. Trouble at Zenith)