### PR TITLE
Add outfit glamour definitions

### DIFF
--- a/SaintCoinach/Definitions/MirageStoreSetItemLookup.json
+++ b/SaintCoinach/Definitions/MirageStoreSetItemLookup.json
@@ -1,15 +1,14 @@
 {
-  "sheet": "MirageStoreSetItem",
+  "sheet": "MirageStoreSetItemLookup",
   "definitions": [
     {
-      "index": 2,
       "type": "repeat",
-      "count": 9,
+      "count": 2,
       "definition": {
-        "name": "Item",
+        "name": "MirageStoreSetItem",
         "converter": {
           "type": "link",
-          "target": "Item"
+          "target": "MirageStoreSetItem"
         }
       }
     }


### PR DESCRIPTION
The `Key` column of `MirageStoreSetItem` is actually an Item link, but I can't recall if that's something we can actually define. Ideally we would like to set up that link and designate it as the default column.