### PR TITLE
Update MapCommand.cs

### DIFF
--- a/SaintCoinach.Cmd/Commands/MapCommand.cs
+++ b/SaintCoinach.Cmd/Commands/MapCommand.cs
@@ -48,7 +48,19 @@ namespace SaintCoinach.Cmd.Commands {
                     outPathSb.AppendFormat("{0}/{1}", map.Id.ToString().Split('/')[0], map.Id.ToString().Replace("/", "."));
                     outPathSb.Append(FormatToExtension(format));
                 } else {
-                    var territoryName = map.TerritoryType?.Name?.ToString();
+                    // this line is occasionally throwing an exception at map.TerritoryType
+                    //var territoryName = map.TerritoryType?.Name?.ToString();
+
+                    // I wrapped the line in a try/catch just to have the loop continue to process other maps when it encounters an exception.
+                    string territoryName = "";
+                    try {
+                        territoryName = map.TerritoryType?.Name?.ToString();
+                    }
+                    catch (Exception ex) {
+                        OutputError($"Error processing map {map.Id}: {ex.Message}");
+                        continue;
+                    }
+
                     if (!string.IsNullOrEmpty(territoryName)) {
                         if (territoryName.Length < 3) {
                             outPathSb.AppendFormat("{0}/", territoryName);


### PR DESCRIPTION
added a workaround to continue processing maps when map.TerritoryType would throw an exception.

as of patch 7.25 using the "maps" command would cause the export process to throw when attempting to export "The Peaks".  I'm just catching the exception and continuing the loop since other maps can still be exported.