### PR TITLE
Fix/64bit support

### DIFF
--- a/Godbert/ViewModels/TerritoryViewModel.cs
+++ b/Godbert/ViewModels/TerritoryViewModel.cs
@@ -143,6 +143,16 @@ namespace Godbert.ViewModels {
                 Dictionary<string, bool> exportedPaths = new Dictionary<string, bool>();
                 UInt64 vs = 1, vt = 1, vn = 1, i = 0;
                 Matrix IdentityMatrix = Matrix.Identity;
+                const int VertLineFlushThreshold = 50000;
+
+                void FlushVertLines(bool force = false) {
+                    if (!force && vertStr.Count < VertLineFlushThreshold)
+                        return;
+                    if (vertStr.Count == 0)
+                        return;
+                    System.IO.File.AppendAllLines(_ExportFileName, vertStr);
+                    vertStr.Clear();
+                }
 
                 void ExportMaterials(Material m, string path) {
                     vertStr.Add($"mtllib {path}.mtl");
@@ -164,14 +174,26 @@ namespace Godbert.ViewModels {
                         if (mtlName.Contains("_dummy_"))
                             continue;
 
-                        var ddsBytes = SaintCoinach.Imaging.ImageConverter.GetDDS(img);
+                        byte[] ddsBytes = null;
+                        var fileExt = ".png";
+                        try {
+                            ddsBytes = SaintCoinach.Imaging.ImageConverter.GetDDS(img);
+                            fileExt = ddsBytes != null ? ".dds" : ".png";
 
-                        var fileExt = ddsBytes != null ? ".dds" : ".png";
-                        
-                        if (fileExt == ".dds")
-                            System.IO.File.WriteAllBytes($"{_ExportDirectory}/{mtlName}.dds", ddsBytes);
-                        else
-                            SaintCoinach.Imaging.ImageConverter.Convert(img).Save($"{_ExportDirectory}/{mtlName}.png");
+                            if (fileExt == ".dds") {
+                                System.IO.File.WriteAllBytes($"{_ExportDirectory}/{mtlName}.dds", ddsBytes);
+                            }
+                            else {
+                                using (var convertedImage = SaintCoinach.Imaging.ImageConverter.Convert(img)) {
+                                    convertedImage.Save($"{_ExportDirectory}/{mtlName}.png", System.Drawing.Imaging.ImageFormat.Png);
+                                }
+                            }
+                        }
+                        catch (Exception texEx) {
+                            System.Diagnostics.Debug.WriteLine(
+                                $"Failed to export texture '{img.Path}' ({img.Width}x{img.Height}, {img.Format}) for material '{path}': {texEx.Message}");
+                            continue;
+                        }
 
 
                         if (mtlName.Contains("_n.tex")) {
@@ -235,20 +257,23 @@ namespace Godbert.ViewModels {
                             vertStr.Add($"vt {v.UV.Value.X} {v.UV.Value.Y * -1.0}".Replace(',', '.'));
                             tempVt++;
                         }
+
+                        if (vertStr.Count >= VertLineFlushThreshold)
+                            FlushVertLines();
                     }
                     vertStr.Add($"g {modelFilePath}_{i.ToString()}_{k.ToString()}");
                     vertStr.Add($"usemtl {materialName}");
-                    for (UInt64 j = 0; j + 3 < (UInt64)mesh.Indices.Length + 1; j += 3) {
+                    for (var j = 0; j + 2 < mesh.Indices.Length; j += 3) {
                         vertStr.Add(
                             $"f " +
                             $"{mesh.Indices[j] + vs}/{mesh.Indices[j] + vt}/{mesh.Indices[j] + vn} " +
                             $"{mesh.Indices[j + 1] + vs}/{mesh.Indices[j + 1] + vt}/{mesh.Indices[j + 1] + vn} " +
                             $"{mesh.Indices[j + 2] + vs}/{mesh.Indices[j + 2] + vt}/{mesh.Indices[j + 2] + vn}");
+
+                        if (vertStr.Count >= VertLineFlushThreshold)
+                            FlushVertLines();
                     }
-                    if (i % 1000 == 0) {
-                        System.IO.File.AppendAllLines(_ExportFileName, vertStr);
-                        vertStr.Clear();
-                    }
+                    FlushVertLines();
                     vs += tempVs;
                     vn += tempVn;
                     vt += tempVt;
@@ -339,8 +364,7 @@ namespace Godbert.ViewModels {
                     }
                 }
 
-                System.IO.File.AppendAllLines(_ExportFileName, vertStr);
-                vertStr.Clear();
+                FlushVertLines(true);
                 vs = 1; vn = 1; vt = 1; i = 0;
                 foreach (var lgb in territory.LgbFiles) {
                     foreach (var lgbGroup in lgb.Groups) {
@@ -356,8 +380,7 @@ namespace Godbert.ViewModels {
 
                                 newGroup = false;
 
-                                System.IO.File.AppendAllLines(_ExportFileName, vertStr);
-                                vertStr.Clear();
+                                FlushVertLines(true);
 
                                 //vertStr.Add($"o {lgbGroup.Name}");
 
@@ -461,8 +484,7 @@ namespace Godbert.ViewModels {
                         lightStrs.Clear();
                     }
                 }
-                System.IO.File.AppendAllLines(_ExportFileName, vertStr);
-                vertStr.Clear();
+                FlushVertLines(true);
                 System.IO.File.AppendAllLines(lightsFileName, lightStrs);
                 lightStrs.Clear();
                 System.Windows.Forms.MessageBox.Show("Finished exporting " + territory.Name, "", System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Information);
@@ -471,8 +493,8 @@ namespace Godbert.ViewModels {
                 System.Windows.Forms.MessageBox.Show(e.Message, $"Canceled {teriName} export");
             }
             catch (Exception e) {
-                System.Diagnostics.Debug.WriteLine(e.StackTrace);
-                System.Windows.Forms.MessageBox.Show(e.StackTrace, $"Unable to export {teriName}");
+                System.Diagnostics.Debug.WriteLine(e.ToString());
+                System.Windows.Forms.MessageBox.Show($"{e.GetType().FullName}: {e.Message}{Environment.NewLine}{e.StackTrace}", $"Unable to export {teriName}");
             }
         }
         #endregion

--- a/SaintCoinach/ByteArrayExtensions.cs
+++ b/SaintCoinach/ByteArrayExtensions.cs
@@ -14,6 +14,8 @@ namespace SaintCoinach {
         public static T ToStructure<T>(this byte[] bytes, ref int offset) where T : struct {
             var t = typeof(T);
             var size = Marshal.SizeOf(t);
+            if (offset < 0 || size < 0 || offset > bytes.Length - size)
+                throw new System.IO.InvalidDataException($"Structure read out of range. Type={t.Name}, Offset={offset}, Size={size}, BufferLength={bytes.Length}.");
             IntPtr ptr = Marshal.AllocHGlobal(size);
             try {
                 Marshal.Copy(bytes, offset, ptr, size);
@@ -38,13 +40,21 @@ namespace SaintCoinach {
             return ReadString(buffer, ref offset);
         }
         public static string ReadString(this byte[] buffer, ref int offset) {
-            var strEnd = offset - 1;
-            while (buffer[++strEnd] != 0) { }
+            if (offset < 0 || offset >= buffer.Length)
+                return string.Empty;
+
+            var strEnd = Array.IndexOf(buffer, (byte)0, offset);
+            if (strEnd < 0)
+                strEnd = buffer.Length;
+
             var size = strEnd - offset;
+            if (size <= 0) {
+                offset = strEnd < buffer.Length ? strEnd + 1 : buffer.Length;
+                return string.Empty;
+            }
 
             var value = Encoding.ASCII.GetString(buffer, offset, size);
-
-            offset = strEnd + 1;
+            offset = strEnd < buffer.Length ? strEnd + 1 : buffer.Length;
             return value;
         }
     }

--- a/SaintCoinach/Graphics/Lgb/LgbModelEntry.cs
+++ b/SaintCoinach/Graphics/Lgb/LgbModelEntry.cs
@@ -38,18 +38,45 @@ namespace SaintCoinach.Graphics.Lgb {
         public Pcb.PcbFile CollisionFile { get; private set; }
         #endregion
 
+        private static string NormalizePath(string value, string extension) {
+            if (string.IsNullOrWhiteSpace(value))
+                return string.Empty;
+
+            var path = value.Trim().Trim('\0').Replace('\\', '/');
+            var roots = new[] { "bg/", "bgcommon/", "common/", "chara/", "vfx/", "cut/" };
+
+            var start = -1;
+            foreach (var root in roots) {
+                var index = path.IndexOf(root, StringComparison.OrdinalIgnoreCase);
+                if (index >= 0 && (start < 0 || index < start))
+                    start = index;
+            }
+            if (start > 0)
+                path = path.Substring(start);
+
+            var extIndex = path.IndexOf(extension, StringComparison.OrdinalIgnoreCase);
+            if (extIndex >= 0)
+                path = path.Substring(0, extIndex + extension.Length);
+
+            return path;
+        }
+
         #region Constructor
         public LgbModelEntry(IO.PackCollection packs, byte[] buffer, int offset) {
             this.Header = buffer.ToStructure<HeaderData>(offset);
             this.Name = buffer.ReadString(offset + Header.NameOffset);
 
-            ModelFilePath = buffer.ReadString(offset + Header.ModelFileOffset);
-            CollisionFilePath = buffer.ReadString(offset + Header.CollisionFileOffset);
+            ModelFilePath = NormalizePath(buffer.ReadString(offset + Header.ModelFileOffset), ".mdl");
+            CollisionFilePath = NormalizePath(buffer.ReadString(offset + Header.CollisionFileOffset), ".pcb");
 
             if (!string.IsNullOrWhiteSpace(ModelFilePath)) {
-                SaintCoinach.IO.File mdlFile;
-                if (packs.TryGetFile(ModelFilePath, out mdlFile))
-                    this.Model = new TransformedModel(((Graphics.ModelFile)mdlFile).GetModelDefinition(), Header.Translation, Header.Rotation, Header.Scale);
+                try {
+                    SaintCoinach.IO.File mdlFile;
+                    if (packs.TryGetFile(ModelFilePath, out mdlFile))
+                        this.Model = new TransformedModel(((Graphics.ModelFile)mdlFile).GetModelDefinition(), Header.Translation, Header.Rotation, Header.Scale);
+                } catch (Exception ex) {
+                    Debug.WriteLine($"{Name} at 0x{offset:X} model '{ModelFilePath}' failure: {ex.Message}");
+                }
             }
             
             if (!string.IsNullOrWhiteSpace(CollisionFilePath)) {

--- a/SaintCoinach/Graphics/Territory.cs
+++ b/SaintCoinach/Graphics/Territory.cs
@@ -21,14 +21,54 @@ namespace SaintCoinach.Graphics {
         public Territory(IO.PackCollection packs, string name, string levelPath) {
             this.Packs = packs;
             this.Name = name;
-            var i = levelPath.IndexOf("/level/");
-            this.BasePath = "bg/" + levelPath.Substring(0, i + 1);
+            this.BasePath = ResolveBasePath(levelPath);
 
             Build();
         }
         #endregion
 
         #region Build
+        private string ResolveBasePath(string levelPath) {
+            var normalized = (levelPath ?? string.Empty).Replace('\\', '/').Trim().Trim('/');
+            if (normalized.StartsWith("bg/", StringComparison.OrdinalIgnoreCase))
+                normalized = normalized.Substring(3);
+
+            var candidates = new List<string>();
+
+            var levelSegmentIndex = normalized.IndexOf("/level/", StringComparison.OrdinalIgnoreCase);
+            if (levelSegmentIndex >= 0)
+                candidates.Add("bg/" + normalized.Substring(0, levelSegmentIndex + 1));
+
+            if (!string.IsNullOrEmpty(normalized))
+                candidates.Add("bg/" + normalized.TrimEnd('/') + "/");
+
+            if (normalized.EndsWith("/level", StringComparison.OrdinalIgnoreCase)) {
+                var withoutLevel = normalized.Substring(0, normalized.Length - "/level".Length).TrimEnd('/');
+                if (!string.IsNullOrEmpty(withoutLevel))
+                    candidates.Add("bg/" + withoutLevel + "/");
+            }
+
+            candidates.Add("bg/");
+
+            foreach (var candidate in candidates.Distinct(StringComparer.OrdinalIgnoreCase)) {
+                if (LooksLikeValidBasePath(candidate)) {
+                    return candidate;
+                } 
+            }
+
+            var fallback = candidates[0];
+            System.Diagnostics.Debug.WriteLine(
+                string.Format("Could not verify territory base path candidates. Bg='{0}', Fallback='{1}'", levelPath, fallback));
+            return fallback;
+        }
+
+        private bool LooksLikeValidBasePath(string basePath) {
+            return Packs.FileExists(basePath + "bgplate/terrain.tera")
+                || Packs.FileExists(basePath + "level/bg.lgb")
+                || Packs.FileExists(basePath + "level/planmap.lgb")
+                || Packs.FileExists(basePath + "level/planevent.lgb");
+        }
+
         private void Build() {
             var terrainPath = BasePath + "bgplate/terrain.tera";
             if (Packs.TryGetFile(terrainPath, out var terrainFile))

--- a/SaintCoinach/IO/Directory.cs
+++ b/SaintCoinach/IO/Directory.cs
@@ -105,7 +105,28 @@ namespace SaintCoinach.IO {
                 return true;
 
             if (Index.Files.TryGetValue(key, out var index)) {
-                var theFile = FileFactory.Get(this.Pack, index);
+                File theFile;
+                try {
+                    theFile = FileFactory.Get(this.Pack, index);
+                } catch (System.IO.InvalidDataException ex) {
+                    System.Diagnostics.Debug.WriteLine(
+                        string.Format("Failed to parse file in TryGetFile. Pack={0}, Dat={1}, Offset=0x{2:X}. {3}",
+                            this.Pack.Id, index.DatFile, index.Offset, ex.Message));
+                    file = null;
+                    return false;
+                } catch (System.IO.EndOfStreamException ex) {
+                    System.Diagnostics.Debug.WriteLine(
+                        string.Format("Unexpected end of stream in TryGetFile. Pack={0}, Dat={1}, Offset=0x{2:X}. {3}",
+                            this.Pack.Id, index.DatFile, index.Offset, ex.Message));
+                    file = null;
+                    return false;
+                } catch (System.NotSupportedException ex) {
+                    System.Diagnostics.Debug.WriteLine(
+                        string.Format("Unsupported file format in TryGetFile. Pack={0}, Dat={1}, Offset=0x{2:X}. {3}",
+                            this.Pack.Id, index.DatFile, index.Offset, ex.Message));
+                    file = null;
+                    return false;
+                }
                 _Files.AddOrUpdate(key,
                     k => new WeakReference<File>(theFile),
                     (k, r) => {

--- a/SaintCoinach/IO/File.cs
+++ b/SaintCoinach/IO/File.cs
@@ -71,6 +71,7 @@ namespace SaintCoinach.IO {
             const int BlockPadding = 0x80;
 
             const int CompressionThreshold = 0x7D00;
+            const int MaxAllowedBlockBytes = 16 * 1024 * 1024;
 
             /*
              * Block:
@@ -96,9 +97,17 @@ namespace SaintCoinach.IO {
             if (magicCheck != Magic)
                 throw new NotSupportedException("Magic number not present (-> don't know how to continue).");
 
+            if (sourceSize <= 0 || rawSize <= 0)
+                throw new InvalidDataException($"Invalid block size. Source={sourceSize}, Raw={rawSize}.");
+
+            if (sourceSize > MaxAllowedBlockBytes || rawSize > MaxAllowedBlockBytes)
+                throw new InvalidDataException($"Block too large. Source={sourceSize}, Raw={rawSize}, Limit={MaxAllowedBlockBytes}.");
+
             var isCompressed = sourceSize < CompressionThreshold;
 
             var blockSize = isCompressed ? sourceSize : rawSize;
+            if (blockSize <= 0 || blockSize > MaxAllowedBlockBytes)
+                throw new InvalidDataException($"Invalid block payload size {blockSize}. Limit={MaxAllowedBlockBytes}.");
 
             // An uncompressed block in an ScdOggFile was corrupted due to this
             // extra padding injecting extra 0s into the output stream.  I'm
@@ -114,7 +123,7 @@ namespace SaintCoinach.IO {
 
             if (isCompressed) {
                 var currentPosition = outStream.Position;
-                Inflate(buffer, outStream);
+                Inflate(buffer, outStream, rawSize);
                 var dLen = outStream.Position - currentPosition;
                 if (dLen != rawSize)
                     throw new InvalidDataException("Inflated block does not match indicated size.");
@@ -123,9 +132,75 @@ namespace SaintCoinach.IO {
             }
         }
 
-        private static void Inflate(byte[] buffer, Stream outStream) {
-            var unc = Ionic.Zlib.DeflateStream.UncompressBuffer(buffer);
-            outStream.Write(unc, 0, unc.Length);
+        private static void Inflate(byte[] buffer, Stream outStream, int expectedSize) {
+            if (expectedSize <= 0)
+                throw new InvalidDataException($"Invalid expected inflated size {expectedSize}.");
+
+            var temp = new byte[8192];
+            var startPos = outStream.CanSeek ? outStream.Position : -1;
+
+            void InflateFrom(Stream decompressor) {
+                var total = 0;
+                while (true) {
+                    var read = decompressor.Read(temp, 0, temp.Length);
+                    if (read <= 0)
+                        break;
+
+                    total += read;
+                    if (total > expectedSize)
+                        throw new InvalidDataException($"Inflated block exceeds expected size. Expected={expectedSize}, Actual>{total}.");
+
+                    outStream.Write(temp, 0, read);
+                }
+            }
+
+            bool LooksLikeZlibHeader(byte[] data) {
+                if (data == null || data.Length < 2)
+                    return false;
+
+                var cmf = data[0];
+                var flg = data[1];
+
+                // RFC1950: compression method must be DEFLATE (8)
+                if ((cmf & 0x0F) != 8)
+                    return false;
+
+                // RFC1950: window size CINFO <= 7
+                if ((cmf >> 4) > 7)
+                    return false;
+
+                // RFC1950: header checksum (CMF*256 + FLG) % 31 == 0
+                return ((cmf << 8) + flg) % 31 == 0;
+            }
+
+            // Pick decompressor by header to avoid flooding first-chance ZlibException in debugger.
+            if (!LooksLikeZlibHeader(buffer)) {
+                using (var compressedStream = new MemoryStream(buffer, false))
+                using (var deflateStream = new Ionic.Zlib.DeflateStream(compressedStream, Ionic.Zlib.CompressionMode.Decompress, false)) {
+                    InflateFrom(deflateStream);
+                }
+                return;
+            }
+
+            try {
+                using (var compressedStream = new MemoryStream(buffer, false))
+                using (var zlibStream = new Ionic.Zlib.ZlibStream(compressedStream, Ionic.Zlib.CompressionMode.Decompress, false)) {
+                    InflateFrom(zlibStream);
+                }
+                return;
+            } catch (Ionic.Zlib.ZlibException) {
+                if (startPos >= 0)
+                    outStream.Position = startPos;
+            }
+
+            try {
+                using (var compressedStream = new MemoryStream(buffer, false))
+                using (var deflateStream = new Ionic.Zlib.DeflateStream(compressedStream, Ionic.Zlib.CompressionMode.Decompress, false)) {
+                    InflateFrom(deflateStream);
+                }
+            } catch (Exception ex) {
+                throw new InvalidDataException("Unable to inflate block with zlib/deflate fallback.", ex);
+            }
         }
 
         #endregion

--- a/SaintCoinach/IO/FileCommonHeader.cs
+++ b/SaintCoinach/IO/FileCommonHeader.cs
@@ -48,6 +48,7 @@ namespace SaintCoinach.IO {
             const int FileTypeOffset = 0x04;
             const int FileLengthOffset = 0x10;
             const int FileLengthShift = 7;
+            const int MinHeaderLength = 4;
 
             if (!stream.CanSeek)
                 throw new NotSupportedException("Stream must be able to seek.");
@@ -57,10 +58,20 @@ namespace SaintCoinach.IO {
                 throw new EndOfStreamException();
 
             var length = BitConverter.ToInt32(_Buffer, 0);
+            var remaining = stream.Length - stream.Position;
+            if (length < MinHeaderLength || length > remaining + MinHeaderLength) {
+                throw new InvalidDataException(
+                    string.Format(
+                        "Invalid SqPack file header length {0} at dat {1} offset 0x{2:X}. Remaining bytes: {3}.",
+                        length,
+                        Index.DatFile,
+                        Index.Offset,
+                        remaining + MinHeaderLength));
+            }
             Array.Resize(ref _Buffer, length);
 
-            var remaining = length - 4;
-            if (stream.Read(_Buffer, 4, remaining) != remaining)
+            var bodyLength = length - MinHeaderLength;
+            if (stream.Read(_Buffer, MinHeaderLength, bodyLength) != bodyLength)
                 throw new EndOfStreamException();
 
             FileType = (FileType)BitConverter.ToInt32(_Buffer, FileTypeOffset);

--- a/SaintCoinach/IO/IIndexFile.cs
+++ b/SaintCoinach/IO/IIndexFile.cs
@@ -8,7 +8,7 @@ namespace SaintCoinach.IO {
     public interface IIndexFile : IEquatable<IIndexFile> {
         PackIdentifier PackId { get; }
         uint FileKey { get; }
-        uint Offset { get; }
+        long Offset { get; }
         byte DatFile { get; }
     }
 }

--- a/SaintCoinach/IO/Index2File.cs
+++ b/SaintCoinach/IO/Index2File.cs
@@ -11,7 +11,7 @@ namespace SaintCoinach.IO {
 
         public PackIdentifier PackId { get; private set; }
         public uint FileKey { get; private set; }
-        public uint Offset { get; private set; }
+        public long Offset { get; private set; }
 
         /// <summary>
         ///     In which .dat* file the data is located.
@@ -26,9 +26,11 @@ namespace SaintCoinach.IO {
             PackId = packId;
             FileKey = reader.ReadUInt32();
 
-            var baseOffset = reader.ReadInt32();
-            DatFile = (byte)((baseOffset & 0x7) >> 1);
-            Offset = (uint)((baseOffset & 0xFFFFFFF8) << 3);
+            var baseOffset = reader.ReadUInt32();
+            // Index2 stores the same low-nibble flags layout as Index:
+            // bit0 = flag, bits1-3 = dat file id, upper bits = offset/8.
+            DatFile = (byte)((baseOffset & 0x000F) >> 1);
+            Offset = ((long)(baseOffset & 0xFFFFFFF0u)) * 0x08L;
         }
 
         #endregion
@@ -36,7 +38,7 @@ namespace SaintCoinach.IO {
         #region IEquatable<IIndexFile> Members
 
         public override int GetHashCode() {
-            return (int)(((DatFile << 24) | PackId.GetHashCode()) ^ Offset);
+            return (int)(((DatFile << 24) | PackId.GetHashCode()) ^ Offset.GetHashCode());
         }
         public override bool Equals(object obj) {
             if (obj is IIndexFile)

--- a/SaintCoinach/IO/Index2Source.cs
+++ b/SaintCoinach/IO/Index2Source.cs
@@ -61,7 +61,27 @@ namespace SaintCoinach.IO {
                 return true;
 
             if (Index.Files.TryGetValue(hash, out var index)) {
-                value = FileFactory.Get(this.Pack, index);
+                try {
+                    value = FileFactory.Get(this.Pack, index);
+                } catch (System.IO.InvalidDataException ex) {
+                    System.Diagnostics.Debug.WriteLine(
+                        string.Format("Failed to parse file in TryGetFile. Pack={0}, Dat={1}, Offset=0x{2:X}. {3}",
+                            this.Pack.Id, index.DatFile, index.Offset, ex.Message));
+                    value = null;
+                    return false;
+                } catch (System.IO.EndOfStreamException ex) {
+                    System.Diagnostics.Debug.WriteLine(
+                        string.Format("Unexpected end of stream in TryGetFile. Pack={0}, Dat={1}, Offset=0x{2:X}. {3}",
+                            this.Pack.Id, index.DatFile, index.Offset, ex.Message));
+                    value = null;
+                    return false;
+                } catch (System.NotSupportedException ex) {
+                    System.Diagnostics.Debug.WriteLine(
+                        string.Format("Unsupported file format in TryGetFile. Pack={0}, Dat={1}, Offset=0x{2:X}. {3}",
+                            this.Pack.Id, index.DatFile, index.Offset, ex.Message));
+                    value = null;
+                    return false;
+                }
                 if (_Files.ContainsKey(hash))
                     _Files[hash].SetTarget(value);
                 else

--- a/SaintCoinach/IO/IndexFile.cs
+++ b/SaintCoinach/IO/IndexFile.cs
@@ -10,7 +10,7 @@ namespace SaintCoinach.IO {
         public PackIdentifier PackId { get; private set; }
         public uint FileKey { get; private set; }
         public uint DirectoryKey { get; private set; }
-        public uint Offset { get; private set; }
+        public long Offset { get; private set; }
 
         /// <summary>
         ///     In which .dat* file the data is located.
@@ -26,9 +26,9 @@ namespace SaintCoinach.IO {
             FileKey = reader.ReadUInt32();
             DirectoryKey = reader.ReadUInt32();
 
-            var baseOffset = reader.ReadInt32();
-            DatFile = (byte)((baseOffset & 0x000F) / 2);
-            Offset = (uint)(baseOffset - (baseOffset & 0x000F)) * 0x08;
+            var baseOffset = reader.ReadUInt32();
+            DatFile = (byte)((baseOffset & 0x000F) >> 1);
+            Offset = ((long)(baseOffset & 0xFFFFFFF0u)) * 0x08L;
 
             reader.ReadInt32(); // Zero
         }
@@ -38,7 +38,7 @@ namespace SaintCoinach.IO {
         #region IEquatable<IIndexFile> Members
 
         public override int GetHashCode() {
-            return (int)(((DatFile << 24) | PackId.GetHashCode()) ^ Offset);
+            return (int)(((DatFile << 24) | PackId.GetHashCode()) ^ Offset.GetHashCode());
         }
         public override bool Equals(object obj) {
             if (obj is IIndexFile)

--- a/SaintCoinach/IO/Pack.cs
+++ b/SaintCoinach/IO/Pack.cs
@@ -23,6 +23,7 @@ namespace SaintCoinach.IO {
 
         private readonly Dictionary<Tuple<Thread, byte>, WeakReference<Stream>> _DataStreams =
             new Dictionary<Tuple<Thread, byte>, WeakReference<Stream>>();
+        private readonly IPackSource _AlternateSource;
 
         private bool _KeepInMemory = false;
         private Dictionary<int, byte[]> _Buffers = new Dictionary<int,byte[]>();
@@ -119,9 +120,11 @@ namespace SaintCoinach.IO {
 
             var indexPath = Path.Combine(DataDirectory.FullName, id.Expansion, string.Format(IndexFileFormat, Id.TypeKey, Id.ExpansionKey, Id.Number));
             var index2Path = Path.Combine(DataDirectory.FullName, id.Expansion, string.Format(Index2FileFormat, Id.TypeKey, Id.ExpansionKey, Id.Number));
-            if (IOFile.Exists(indexPath))
+            if (IOFile.Exists(indexPath)) {
                 Source = new IndexSource(this, new Index(id, indexPath));
-            else if (IOFile.Exists(index2Path))
+                if (IOFile.Exists(index2Path))
+                    _AlternateSource = new Index2Source(this, new Index2(id, index2Path));
+            } else if (IOFile.Exists(index2Path))
                 Source = new Index2Source(this, new Index2(id, index2Path));
             else
                 throw new FileNotFoundException();
@@ -132,13 +135,23 @@ namespace SaintCoinach.IO {
         #region Fields
 
         public bool FileExists(string path) {
-            return Source.FileExists(path);
+            return Source.FileExists(path) || (_AlternateSource != null && _AlternateSource.FileExists(path));
         }
         public bool TryGetFile(string path, out File value) {
-            return Source.TryGetFile(path, out value);
+            if (_AlternateSource != null && _AlternateSource.TryGetFile(path, out value)) {
+                return true;
+            }
+
+            if (Source.TryGetFile(path, out value))
+                return true;
+
+            value = null;
+            return false;
         }
         public File GetFile(string path) {
-            return Source.GetFile(path);
+            if (TryGetFile(path, out var value))
+                return value;
+            throw new FileNotFoundException("Pack file not found '" + path + "'");
         }
 
         #endregion

--- a/SaintCoinach/Imaging/ImageConverter.cs
+++ b/SaintCoinach/Imaging/ImageConverter.cs
@@ -70,6 +70,8 @@ namespace SaintCoinach.Imaging {
     ///     to formats useable in .NET
     /// </summary>
     public class ImageConverter {
+        private const long MaxDecodedArgbBytes = 256L * 1024L * 1024L;
+
         /// <summary>
         ///     Method signature for processing data as stored in SqPack into ARGB.
         /// </summary>
@@ -138,7 +140,16 @@ namespace SaintCoinach.Imaging {
             if (!Preprocessors.TryGetValue(format, out var proc))
                 throw new NotSupportedException(string.Format("Unsupported image format {0}", format));
 
-            var argb = new byte[width * height * 4];
+            if (width <= 0 || height <= 0)
+                throw new System.IO.InvalidDataException($"Invalid image dimensions {width}x{height} for format {format}.");
+
+            var pixelCount = (long)width * height;
+            var byteCount = pixelCount * 4;
+            if (byteCount <= 0 || byteCount > MaxDecodedArgbBytes)
+                throw new System.IO.InvalidDataException(
+                    $"Decoded image is too large ({width}x{height}, {byteCount} bytes) for format {format}. Limit={MaxDecodedArgbBytes} bytes.");
+
+            var argb = new byte[(int)byteCount];
             proc(src, argb, width, height);
             return argb;
         }
@@ -148,10 +159,24 @@ namespace SaintCoinach.Imaging {
         /// </summary>
 
         public static byte[] GetDDS(ImageFile file) {
-            var bytes2 = file.GetData();
-            //var offset = bytes2[file.ImageHeader.EndOfHeader];
             var width = file.ImageHeader.Width;
             var height = file.ImageHeader.Height;
+            var imageFormat = file.ImageHeader.Format;
+            var addDx10Header = false;
+
+            switch (imageFormat) {
+                case ImageFormat.Dxt1:
+                case ImageFormat.Dxt3:
+                case ImageFormat.Dxt5:
+                case ImageFormat.BC5:
+                case ImageFormat.BC7:
+                    break;
+                default:
+                    return null;
+            }
+
+            var bytes2 = file.GetData();
+            //var offset = bytes2[file.ImageHeader.EndOfHeader];
 
             DDS_HEADER header = new DDS_HEADER();
             DDS_PIXELFORMAT format = header.ddspf;
@@ -161,7 +186,7 @@ namespace SaintCoinach.Imaging {
             header.dwFlags |= (uint)(DDSD_ENUM.DDSD_CAPS | DDSD_ENUM.DDSD_HEIGHT | DDSD_ENUM.DDSD_WIDTH | DDSD_ENUM.DDSD_PIXELFORMAT | DDSD_ENUM.DDSD_LINEARSIZE);
             header.dwFlags |= (uint)DDSD_ENUM.DDSD_MIPMAPCOUNT;
 
-            switch (file.ImageHeader.Format) {
+            switch (imageFormat) {
                 case ImageFormat.Dxt1:
                     format.dwFourCC = 0x31545844;
                     header.dwPitchOrLinearSize = (uint)(Math.Max((uint)1, ((width + 3) / 4)) * Math.Max((uint)1, ((height + 3) / 4)) * 8);
@@ -173,6 +198,17 @@ namespace SaintCoinach.Imaging {
                 case ImageFormat.Dxt5:
                     format.dwFourCC = 0x35545844;
                     header.dwPitchOrLinearSize = (uint)(Math.Max((uint)1, ((width + 3) / 4)) * Math.Max((uint)1, ((height + 3) / 4)) * 16);
+                    break;
+                case ImageFormat.BC5:
+                    // 'ATI2' block-compressed normal map format.
+                    format.dwFourCC = 0x32495441;
+                    header.dwPitchOrLinearSize = (uint)(Math.Max((uint)1, ((width + 3) / 4)) * Math.Max((uint)1, ((height + 3) / 4)) * 16);
+                    break;
+                case ImageFormat.BC7:
+                    // BC7 requires DX10 extension header.
+                    format.dwFourCC = 0x30315844; // "DX10"
+                    header.dwPitchOrLinearSize = (uint)(Math.Max((uint)1, ((width + 3) / 4)) * Math.Max((uint)1, ((height + 3) / 4)) * 16);
+                    addDx10Header = true;
                     break;
                 /*
                 case ImageFormat.A8R8G8B8_1:
@@ -187,9 +223,7 @@ namespace SaintCoinach.Imaging {
                     break;
                 */
                 default:
-                    System.Diagnostics.Debug.WriteLine("Texture format " + file.ImageHeader.Format.ToString() + " DDS export not supported!\n");
                     return null;
-                    break;
             }
 
             format.dwSize = 32;
@@ -214,6 +248,14 @@ namespace SaintCoinach.Imaging {
 
             data.AddRange(System.Text.ASCIIEncoding.UTF8.GetBytes("DDS "));
             data.AddRange(headerBytes);
+            if (addDx10Header) {
+                // DDS_HEADER_DXT10
+                data.AddRange(BitConverter.GetBytes((uint)98)); // DXGI_FORMAT_BC7_UNORM
+                data.AddRange(BitConverter.GetBytes((uint)3));  // D3D10_RESOURCE_DIMENSION_TEXTURE2D
+                data.AddRange(BitConverter.GetBytes((uint)0));  // miscFlag
+                data.AddRange(BitConverter.GetBytes((uint)1));  // arraySize
+                data.AddRange(BitConverter.GetBytes((uint)0));  // miscFlags2
+            }
             data.AddRange(bytes2);
 
             return data.ToArray();


### PR DESCRIPTION
## [中文] PR 说明

### 背景与目标
本 PR 主要修复新版地图（如 `x6rb` / `x6rc_2`）在加载与导出过程中的一组连锁问题，包括：
- Territory 打开失败（`ArgumentOutOfRangeException` / `InvalidDataException`）
- 读取 SqPack 文件头异常（header length 为负数或 0）
- 导出阶段出现 `OutOfMemoryException` / `ZlibException`
- 部分 LGB/SGB 模型路径异常导致资源漏导出
- 纹理导出在 BC7/BC5 场景下不稳定

### 根因概述
1. **Index / Index2 偏移量与 dat 选择解析不完整**  
   旧逻辑在偏移计算和 source 选择上对新版数据不够稳健，导致读取到错误 dat 偏移。
2. **Territory BasePath 推断不够健壮**  
   `Bg` 字段在不同地图结构下存在差异，导致拼接路径失配。
3. **SqPack 文件头与 block 解压缺少边界保护**  
   对异常长度、异常尺寸、压缩流类型切换（zlib/deflate）保护不足，易触发 OOM 或异常风暴。
4. **LGB 模型路径字符串未规范化**  
   某些记录包含前缀噪声/不规范分隔符，触发路径解析异常或查找失败。
5. **导出纹理时缺少格式与内存边界控制**  
   高分辨率/压缩纹理在解码导出时容易造成峰值内存过高或不支持格式报错。

### 主要改动
#### 1) Index 与 Pack 读取链路修正
- `IIndexFile.Offset` 改为 `long`，统一支持更大偏移。
- 修正 `IndexFile` / `Index2File` 对 dat 标记与实际偏移的解析。
- `Pack.TryGetFile` 优先尝试 `Index2Source`（若可用），回退到 `IndexSource`。
- 相关文件：  
  `SaintCoinach/IO/IIndexFile.cs`  
  `SaintCoinach/IO/IndexFile.cs`  
  `SaintCoinach/IO/Index2File.cs`  
  `SaintCoinach/IO/Pack.cs`

#### 2) Territory 路径解析增强
- 新增候选路径推断与有效性验证（`terrain.tera` / `bg.lgb` / `planmap.lgb` / `planevent.lgb`）。
- 在无法直接验证时保留可追踪日志并使用可回退策略。
- 相关文件：  
  `SaintCoinach/Graphics/Territory.cs`

#### 3) SqPack 读取与解压健壮性增强
- `FileCommonHeader` 增加 header 长度合法性检查，阻止负值/越界长度。
- `File.ReadBlock` 增加 block 大小、解压后尺寸、一致性校验。
- `Inflate` 增加 zlib header 判定，按数据特征选择 zlib/deflate，减少错误解压路径。
- `Directory` / `Index2Source` 在 `TryGetFile` 中对损坏文件做可诊断日志并安全跳过。
- `ByteArrayExtensions` 增加结构读取越界保护与字符串读取边界修正。
- 相关文件：  
  `SaintCoinach/IO/FileCommonHeader.cs`  
  `SaintCoinach/IO/File.cs`  
  `SaintCoinach/IO/Directory.cs`  
  `SaintCoinach/IO/Index2Source.cs`  
  `SaintCoinach/ByteArrayExtensions.cs`

#### 4) LGB 模型路径规范化
- 统一路径分隔符，提取有效根路径（`bg/`, `common/`, `chara/` 等），裁剪到合法扩展名。
- 避免异常字符串导致的 `startIndex` 问题与模型漏加载。
- 相关文件：  
  `SaintCoinach/Graphics/Lgb/LgbModelEntry.cs`

#### 5) 导出流程与纹理处理稳定性
- 导出时增加分批 flush，降低 OBJ 大量字符串累计导致的内存压力。
- 纹理导出支持 BC5/BC7 的 DDS 输出（BC7 增加 DX10 header）。
- 增加图像尺寸与解码字节上限保护，避免异常数据触发 OOM。
- 纹理导出失败时按单资源记录并跳过，不中断整图导出。
- 相关文件：  
  `Godbert/ViewModels/TerritoryViewModel.cs`  
  `SaintCoinach/Imaging/ImageConverter.cs`

### 结果与影响
- 新地图 territory 的加载成功率显著提升（尤其是 `x6rb` 类路径）。
- 导出流程从“遇错中断”改为“可诊断 + 尽量继续导出”，减少整批失败。
- 对损坏/异常资源引入更明确的错误信息，便于后续定位。
- 兼容性上主要是增强与边界保护，不改变正常资源的既有解析结果。

### 测试与验证
- 手动验证 territory 打开、模型加载、纹理导出与整图导出流程。
- 针对典型报错路径（header 长度异常、zlib/deflate、BC7 纹理）进行回归验证。
- 本 PR 不包含日志文件，仅包含代码变更。

### AI 生成与人工复核声明
本 PR 的代码由 **OpenAI Codex** 协助生成；提交者已进行**逐项人工审查、手动调试与结果验证**，并按功能相关性拆分为独立 commits。

---

## [English] PR Description

### Background and Goal
This PR fixes a chain of issues encountered when loading/exporting newer territories (e.g. `x6rb` / `x6rc_2`), including:
- territory open failures (`ArgumentOutOfRangeException` / `InvalidDataException`)
- invalid SqPack file header parsing (negative/zero header length)
- `OutOfMemoryException` / `ZlibException` during export
- missing exports due to malformed LGB/SGB model paths
- unstable BC5/BC7 texture export behavior

### Root Cause Summary
1. **Index/Index2 offset + dat selection handling was incomplete** for newer data layout.
2. **Territory base path inference was fragile** for variant `Bg` strings.
3. **SqPack header/block parsing lacked strict bounds checks**, enabling bad lengths and decompression blowups.
4. **LGB model path strings were not normalized**, causing invalid indexing/path lookup failures.
5. **Texture export lacked enough format/memory safeguards** for large compressed textures.

### Key Changes
#### 1) Index and Pack read-path fixes
- `IIndexFile.Offset` is now `long`.
- Corrected dat flag and offset decoding in `IndexFile` / `Index2File`.
- `Pack.TryGetFile` now prefers `Index2Source` when available, then falls back to `IndexSource`.
- Files:
  `SaintCoinach/IO/IIndexFile.cs`  
  `SaintCoinach/IO/IndexFile.cs`  
  `SaintCoinach/IO/Index2File.cs`  
  `SaintCoinach/IO/Pack.cs`

#### 2) Stronger Territory base-path resolution
- Added candidate generation + validation against known assets (`terrain.tera`, `bg.lgb`, `planmap.lgb`, `planevent.lgb`).
- Added traceable fallback behavior when no candidate can be verified.
- File:
  `SaintCoinach/Graphics/Territory.cs`

#### 3) Hardened SqPack header/block parsing
- Added strict header-length validation in `FileCommonHeader`.
- Added block size / inflated size / consistency checks in `File.ReadBlock`.
- Added zlib-header detection and zlib/deflate fallback strategy in `Inflate`.
- Added recoverable diagnostics in `Directory` / `Index2Source` for malformed files.
- Added out-of-range structure/string read guards in `ByteArrayExtensions`.
- Files:
  `SaintCoinach/IO/FileCommonHeader.cs`  
  `SaintCoinach/IO/File.cs`  
  `SaintCoinach/IO/Directory.cs`  
  `SaintCoinach/IO/Index2Source.cs`  
  `SaintCoinach/ByteArrayExtensions.cs`

#### 4) LGB model path normalization
- Normalized separators and extracted valid content roots (`bg/`, `common/`, `chara/`, etc.).
- Trimmed paths to expected extensions to prevent malformed string/index errors.
- File:
  `SaintCoinach/Graphics/Lgb/LgbModelEntry.cs`

#### 5) Export stability + texture handling improvements
- Added periodic output flushing to reduce peak memory pressure during OBJ export.
- Added DDS export support for BC5/BC7 (`DX10` header for BC7).
- Added image dimension and decoded-size guards to prevent OOM on malformed/extreme inputs.
- Texture-level failures are logged and skipped without aborting the full territory export.
- Files:
  `Godbert/ViewModels/TerritoryViewModel.cs`  
  `SaintCoinach/Imaging/ImageConverter.cs`

### Impact
- Significantly improves territory load success for newer map content.
- Export path is now more fault-tolerant: better diagnostics and fewer full-run aborts.
- Better protection against malformed/corrupt resource data.
- Changes are primarily defensive and compatibility-oriented for valid assets.

### Validation
- Manual verification of territory opening, model loading, texture export, and full export flow.
- Regression checks around previously failing cases (invalid header lengths, zlib/deflate cases, BC7 textures).
- No log files are included in this PR; code changes only.

### AI + Human Review Disclosure
The implementation in this PR was assisted/generated by **OpenAI Codex**.  
The contributor performed **manual review, debugging, and validation** before preparing the final commits.
